### PR TITLE
Adds a preso list page

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -9,6 +9,6 @@ const Footer = () => (
       ngosi
     </a>
   </footer>
-);
+)
 
-export default Footer;
+export default Footer

--- a/pages/preso.tsx
+++ b/pages/preso.tsx
@@ -45,6 +45,15 @@ const Preso: NextPage = () => {
           <div className="mt-6">
             <PresentationForm onSubmit={(values) => onSubmit(values)} />
           </div>
+          <button
+            className="w-full h-14 bg-black text-white font-bold text-xl mt-5"
+            type="button"
+            onClick={() => {
+              router.replace('presos')
+            }}
+          >
+            Cancel
+          </button>
         </div>
       </main>
       <Footer />

--- a/pages/preso.tsx
+++ b/pages/preso.tsx
@@ -48,7 +48,6 @@ const Preso: NextPage = () => {
         </div>
       </main>
       <Footer />
-      <pre>{JSON.stringify({ authState, session }, null, 2)}</pre>
     </div>
   )
 }

--- a/pages/presos.tsx
+++ b/pages/presos.tsx
@@ -1,0 +1,69 @@
+import { useSupabase } from '@common/useSupabase'
+import Footer from '@components/Footer'
+import { Preso } from '@types'
+import { NextPage } from 'next'
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+
+const Presos: NextPage = () => {
+  const router = useRouter()
+  const [presos, setPresos] = useState<Preso[]>([])
+  const { authState, session, supabaseClient } = useSupabase()
+
+  useEffect(() => {
+    const loadPresos = async () => {
+      if (!session) {
+        return
+      }
+
+      const { error, data } = await supabaseClient
+        .from<Preso>('Preso')
+        .select()
+        .eq('userId', session?.user?.id)
+        .order('createdAt', { ascending: false })
+
+      if (error) {
+        console.error(error)
+        return
+      }
+
+      setPresos(data || [])
+    }
+
+    loadPresos()
+  }, [supabaseClient, session])
+
+  return (
+    <div className="flex flex-col min-h-screen min-w-full">
+      <Head>
+        <title>Ngosi</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <main className="flex flex-col flex-1">
+        <h1 className="text-3xl bg-black py-2 px-6 text-white">Your Presos</h1>
+        <div className="pt-4 px-6">
+          <div className="mt-6">
+            <ul>
+              {presos.map((p) => (
+                <li key={p.id}>{p.eventName}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+        <button
+          className="w-full h-14 bg-black text-white font-bold text-xl mt-5"
+          type="button"
+          onClick={() => {
+            router.push('preso')
+          }}
+        >
+          Add New Preso
+        </button>
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+export default Presos

--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -32,6 +32,15 @@ const Qr: NextPage = () => {
         >
           Download QR
         </button>
+        <button
+          className="w-full h-14 bg-black text-white font-bold text-xl mt-5"
+          type="button"
+          onClick={() => {
+            router.push('/presos')
+          }}
+        >
+          Continue to your presos
+        </button>
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
Fixes #30

## Solution

This PR adds a new page where a presenter's presentations can be viewed. Note that this PR only includes changes necessary to view presos, no interactivity is included.

Other changes:
* Added a button to the preso creation page (`/preso`) to cancel creating a new preso and take you back to your preso list.
* Added button on preso list page to create a new preso.

## Testing

This video explains what needs to be done to test this change.

https://user-images.githubusercontent.com/1715082/147287593-a37c27b6-e300-4d53-bf4d-76ac0a482c7a.mp4
