### PR TITLE
Convert useSupabase hook to use the provider pattern

### DIFF
--- a/common/supabaseProvider.tsx
+++ b/common/supabaseProvider.tsx
@@ -5,18 +5,19 @@ import {
   SupabaseClient
 } from '@supabase/supabase-js'
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { SupabaseAnonKey, SupabaseUrl } from './constants'
 
-export type AuthState = 'authenticated' | 'not-authenticated'
+type AuthState = 'authenticated' | 'not-authenticated'
+interface SupabaseContext {
+  readonly authState: AuthState
+  readonly session: Session | null
+  readonly supabaseClient: SupabaseClient
+}
 
-export const supabaseClient = createClient(SupabaseUrl, SupabaseAnonKey)
-
-export const useSupabase = (): {
-  authState: AuthState
-  session: Session | null
-  supabaseClient: SupabaseClient
-} => {
+const supabaseClient = createClient(SupabaseUrl, SupabaseAnonKey)
+const supabaseContext = React.createContext<SupabaseContext | null>(null)
+const SupabaseProvider: React.FC = ({ children }) => {
   const [session, setSession] = useState<Session | null>(null)
   const [authState, setAuthState] = useState<AuthState>('not-authenticated')
   const router = useRouter()
@@ -66,5 +67,19 @@ export const useSupabase = (): {
     }
   }, [router, session])
 
-  return { authState, session, supabaseClient }
+  return (
+    <supabaseContext.Provider
+      value={{
+        authState,
+        session,
+        supabaseClient
+      }}
+    >
+      {children}
+    </supabaseContext.Provider>
+  )
 }
+
+export const useSupabase = () => useContext(supabaseContext)!
+
+export default SupabaseProvider

--- a/common/supabaseProvider.tsx
+++ b/common/supabaseProvider.tsx
@@ -25,6 +25,7 @@ const SupabaseProvider: React.FC = ({ children }) => {
   useEffect(() => {
     try {
       setSession(supabaseClient.auth.session())
+
       const { data, error } = supabaseClient.auth.onAuthStateChange((event) => {
         onAuthChanged(event, session)
 
@@ -35,6 +36,8 @@ const SupabaseProvider: React.FC = ({ children }) => {
             break
           case 'SIGNED_OUT':
             setAuthState('not-authenticated')
+            router.replace('/')
+            break
         }
 
         setSession(session)

--- a/components/Account.tsx
+++ b/components/Account.tsx
@@ -1,8 +1,6 @@
-import { useState, useEffect } from 'react'
-import { useSupabase } from '@common/useSupabase'
+import { useSupabase } from '@common/supabaseProvider'
 import type { Session } from '@supabase/supabase-js'
-import { useRouter } from 'next/router'
-import cuid from 'cuid'
+import { useEffect, useState } from 'react'
 
 interface Props {
   session: Session

--- a/components/Auth.tsx
+++ b/components/Auth.tsx
@@ -1,4 +1,4 @@
-import { useSupabase } from '@common/useSupabase'
+import { useSupabase } from '@common/supabaseProvider'
 import { useState } from 'react'
 
 export default function Auth() {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,14 +1,14 @@
 import { useOneSignal } from '@common/useOneSignal'
+import SupabaseProvider from '@common/supabaseProvider'
 import { AppProps } from 'next/app'
-import { RecoilRoot } from 'recoil'
 import '../styles/globals.css'
 
 export default function Ngosi({ Component, pageProps }: AppProps) {
   useOneSignal()
 
   return (
-    <RecoilRoot>
+    <SupabaseProvider>
       <Component {...pageProps} />
-    </RecoilRoot>
+    </SupabaseProvider>
   )
 }

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -1,9 +1,8 @@
-import { useSupabase } from '@common/useSupabase'
+import { useSupabase } from '@common/supabaseProvider'
 import Account from '@components/Account'
 import { NextPage } from 'next'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
 
 const AccountPage: NextPage = () => {
   const { authState, session, supabaseClient } = useSupabase()

--- a/pages/api/auth.ts
+++ b/pages/api/auth.ts
@@ -1,5 +1,5 @@
-import { supabaseClient } from '@common/useSupabase'
 import { NextApiRequest, NextApiResponse } from 'next'
+import { supabaseClient } from './common/supabase'
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   supabaseClient.auth.api.setAuthCookie(req, res)

--- a/pages/api/common/supabase.ts
+++ b/pages/api/common/supabase.ts
@@ -1,0 +1,4 @@
+import { SupabaseUrl, SupabaseAnonKey } from '@common/constants'
+import { createClient } from '@supabase/supabase-js'
+
+export const supabaseClient = createClient(SupabaseUrl, SupabaseAnonKey)

--- a/pages/api/preso.ts
+++ b/pages/api/preso.ts
@@ -1,9 +1,9 @@
-import { supabaseClient } from '@common/useSupabase'
 import { Preso, PresoForm } from '@types'
 import cuid from 'cuid'
 import { nanoid } from 'nanoid'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { StatusCodes } from 'http-status-codes'
+import { supabaseClient } from './common/supabase'
 
 type Data =
   | {

--- a/pages/api/profile.ts
+++ b/pages/api/profile.ts
@@ -1,7 +1,7 @@
-import { supabaseClient } from '@common/useSupabase'
 import { Profile } from '@types'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { StatusCodes } from 'http-status-codes'
+import { supabaseClient } from './common/supabase'
 
 type Data =
   | {

--- a/pages/api/survey-response.ts
+++ b/pages/api/survey-response.ts
@@ -1,8 +1,8 @@
-import { supabaseClient } from '@common/useSupabase'
 import { Attendee, Preso, Survey, SurveyFormResponse } from '@types'
 import cuid from 'cuid'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { StatusCodes } from 'http-status-codes'
+import { supabaseClient } from './common/supabase'
 
 type Data =
   | {

--- a/pages/api/survey.ts
+++ b/pages/api/survey.ts
@@ -1,4 +1,4 @@
-import { supabaseClient } from '@common/useSupabase'
+import { supabaseClient } from './common/supabase'
 import { PresenterHeader, Preso, Profile } from '@types'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { StatusCodes } from 'http-status-codes'

--- a/pages/groupies.tsx
+++ b/pages/groupies.tsx
@@ -1,4 +1,4 @@
-import { useSupabase } from '@common/useSupabase'
+import { useSupabase } from '@common/supabaseProvider'
 import Footer from '@components/Footer'
 import { NextPage } from 'next'
 import Head from 'next/head'

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useSupabase } from '@common/useSupabase'
+import { useSupabase } from '@common/supabaseProvider'
 import Auth from '@components/Auth'
 import { NextPage } from 'next'
 import Head from 'next/head'

--- a/pages/preso.tsx
+++ b/pages/preso.tsx
@@ -1,4 +1,4 @@
-import { useSupabase } from '@common/useSupabase'
+import { useSupabase } from '@common/supabaseProvider'
 import Footer from '@components/Footer'
 import PresentationForm from '@components/PresoForm'
 import { PresoForm } from '@types'

--- a/pages/preso.tsx
+++ b/pages/preso.tsx
@@ -5,7 +5,6 @@ import { PresoForm } from '@types'
 import { NextPage } from 'next'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
 
 const Preso: NextPage = () => {
   const router = useRouter()

--- a/pages/preso.tsx
+++ b/pages/preso.tsx
@@ -5,14 +5,11 @@ import { PresoForm } from '@types'
 import { NextPage } from 'next'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
+import { useEffect } from 'react'
 
 const Preso: NextPage = () => {
   const router = useRouter()
-  const { authState, session } = useSupabase()
-
-  if (!session) {
-    return <div>No logged in user.</div>
-  }
+  const { session } = useSupabase()
 
   const onSubmit = async (values: PresoForm) => {
     try {
@@ -20,7 +17,7 @@ const Preso: NextPage = () => {
         method: 'POST',
         body: JSON.stringify({
           ...values,
-          userId: session?.user?.id
+          userId: session!.user?.id
         } as PresoForm)
       })
       const json = await response.json()

--- a/pages/presos.tsx
+++ b/pages/presos.tsx
@@ -1,4 +1,4 @@
-import { useSupabase } from '@common/useSupabase'
+import { useSupabase } from '@common/supabaseProvider'
 import Footer from '@components/Footer'
 import { Preso } from '@types'
 import { NextPage } from 'next'
@@ -13,7 +13,7 @@ const Presos: NextPage = () => {
 
   useEffect(() => {
     const loadPresos = async () => {
-      if (!session) {
+      if (authState !== 'authenticated') {
         return
       }
 
@@ -32,7 +32,7 @@ const Presos: NextPage = () => {
     }
 
     loadPresos()
-  }, [supabaseClient, session])
+  }, [supabaseClient, session, authState])
 
   return (
     <div className="flex flex-col min-h-screen min-w-full">


### PR DESCRIPTION
Fixes #46.

## Solution
I refactored the `useSupbaseHook` to be back by React context. I also pulled all the logic originally in the hook into a new functional component that will act as a provider to the app. I originally thought this would prevent the app flashing while it computes the auth state, but this is not the case, so I may need to work with someone who's stronger in React to address the issue (see #48). 

## Testing
These changes don't result in a change in behavior, but instead, reactors the `useSupabase` hook to implement the provider pattern. The test for these changes is effectively verifying that it works the same as before.

1. Checkout `dev` branch
2. Start supabase then start the app
3. Log in to the app and create a preso
4. Logout
5. Checkout the PR branch, `git checkout auth-provider`
6. Log in to the app and create a preso
7. Note that there are no differences. 

## Resources

### References
- [What is the provider pattern](https://www.patterns.dev/posts/provider-pattern/)
- [Provider pattern with React context API](https://flexiple.com/react/provider-pattern-with-react-context-api/)


