### PR TITLE
Set initial laoding state on account page to false

### DIFF
--- a/components/Account.tsx
+++ b/components/Account.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const Account: React.FC<Props> = (props) => {
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(false)
   const [username, setUsername] = useState<string | null>(null)
   const [website, setWebsite] = useState<string | null>(null)
   const [avatar_url, setAvatarUrl] = useState<string | null>(null)

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -2,15 +2,9 @@ import { useSupabase } from '@common/supabaseProvider'
 import Account from '@components/Account'
 import { NextPage } from 'next'
 import Head from 'next/head'
-import { useRouter } from 'next/router'
 
 const AccountPage: NextPage = () => {
-  const { authState, session, supabaseClient } = useSupabase()
-  const router = useRouter()
-
-  if (!session) {
-    return <div>No session</div>
-  }
+  const { session, supabaseClient } = useSupabase()
 
   return (
     <div className="h-screen w-screen flex flex-col  items-center justify-center bg-primary">
@@ -21,7 +15,7 @@ const AccountPage: NextPage = () => {
         ></script>
       </Head>
       <h1 className="text-white text-6xl">Ngosi</h1>
-      <Account key={session.user?.id} session={session!} />
+      <Account key={session!.user?.id} session={session!} />
       <button
         className="h-12 bg-black text-white font-bold text-xl mt-5 w-80"
         onClick={async () => {

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -6,6 +6,10 @@ import Head from 'next/head'
 const AccountPage: NextPage = () => {
   const { session, supabaseClient } = useSupabase()
 
+  if (!session) {
+    return <div>No session</div>
+  }
+
   return (
     <div className="h-screen w-screen flex flex-col  items-center justify-center bg-primary">
       <Head>
@@ -15,7 +19,7 @@ const AccountPage: NextPage = () => {
         ></script>
       </Head>
       <h1 className="text-white text-6xl">Ngosi</h1>
-      <Account key={session!.user?.id} session={session!} />
+      <Account key={session.user?.id} session={session!} />
       <button
         className="h-12 bg-black text-white font-bold text-xl mt-5 w-80"
         onClick={async () => {


### PR DESCRIPTION
This PR fixes a bug I came across where the loading state is initially set to `true.`
