### PR TITLE
Add detail page for presos

### DIFF
--- a/common/supabaseProvider.tsx
+++ b/common/supabaseProvider.tsx
@@ -12,7 +12,7 @@ type AuthState = 'authenticated' | 'not-authenticated'
 interface SupabaseContext {
   readonly authState: AuthState
   readonly session: Session | null
-  readonly supabaseClient: SupabaseClient
+  readonly client: SupabaseClient
 }
 
 const supabaseClient = createClient(SupabaseUrl, SupabaseAnonKey)
@@ -75,7 +75,7 @@ const SupabaseProvider: React.FC = ({ children }) => {
       value={{
         authState,
         session,
-        supabaseClient
+        client: supabaseClient
       }}
     >
       {children}

--- a/components/Account.tsx
+++ b/components/Account.tsx
@@ -11,7 +11,7 @@ const Account: React.FC<Props> = (props) => {
   const [username, setUsername] = useState<string | null>(null)
   const [website, setWebsite] = useState<string | null>(null)
   const [avatar_url, setAvatarUrl] = useState<string | null>(null)
-  const { supabaseClient } = useSupabase()
+  const { client: supabaseClient } = useSupabase()
 
   useEffect(() => {
     async function getProfile() {

--- a/components/Auth.tsx
+++ b/components/Auth.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 export default function Auth() {
   const [loading, setLoading] = useState(false)
   const [email, setEmail] = useState('')
-  const { supabaseClient } = useSupabase()
+  const { client: supabaseClient } = useSupabase()
 
   const handleLogin = async (email: string) => {
     try {

--- a/components/PresoDetails.tsx
+++ b/components/PresoDetails.tsx
@@ -1,0 +1,130 @@
+import { Preso, PresoForm as PresoDetails } from '@types'
+import { Field, FieldProps, Form, Formik, FormikErrors } from 'formik'
+import React from 'react'
+import type { Writeable } from '@common/utils'
+
+interface Props {
+  readonly onSubmit: (values: PresoDetails) => Promise<void>
+  readonly preso?: Preso
+}
+
+const onValidate = (values: PresoDetails) => {
+  let errors: FormikErrors<Writeable<PresoDetails>> = {}
+
+  if (!values.title) {
+    errors.title = 'A presentation title is required.'
+  }
+
+  if (!values.url) {
+    errors.url = 'The link to your slides is required.'
+  }
+
+  if (!values.eventName) {
+    errors.eventName = 'A name for the event is required.'
+  }
+
+  return errors
+}
+
+const PresoDetails: React.FC<Props> = (props) => {
+  return (
+    <Formik
+      initialValues={
+        {
+          url: props.preso?.url || '',
+          eventName: props.preso?.eventName || '',
+          title: props.preso?.title || '',
+          eventLocation: props.preso?.eventLocation || ''
+        } as PresoDetails
+      }
+      onSubmit={props.onSubmit}
+      validate={onValidate}
+    >
+      {(formikProps) => (
+        <Form className="flex flex-col space-y-5">
+          <div className="flex flex-col space-y-1">
+            <label
+              className="font-semibold text-sm text-gray-900"
+              htmlFor="url"
+            >
+              Enter link to your presentation
+            </label>
+            <Field name="url">
+              {({ field, form, ...props }: FieldProps<PresoDetails>) => (
+                <>
+                  <input
+                    {...field}
+                    type="url"
+                    onChange={formikProps.handleChange}
+                    onBlur={formikProps.handleBlur}
+                    value={formikProps.values.url}
+                    className="h-12 w-full border border-black text-lg px-2 "
+                    placeholder="https://ngosi.io"
+                  />
+                  {form.touched.url && form.errors.url && (
+                    <div>{form.errors.url}</div>
+                  )}
+                </>
+              )}
+            </Field>
+          </div>
+
+          <div className="flex flex-col space-y-1">
+            <label
+              className="font-semibold text-sm text-gray-900"
+              htmlFor="url"
+            >
+              Title
+            </label>
+            <Field
+              name="title"
+              type="text"
+              className="h-12 w-full border border-black text-lg px-2"
+              placeholder="Yahoo!"
+            ></Field>
+          </div>
+
+          <div className="flex flex-col space-y-1">
+            <label
+              className="font-semibold text-sm text-gray-900"
+              htmlFor="url"
+            >
+              Event Name
+            </label>
+            <Field
+              name="eventName"
+              type="text"
+              className="h-12 w-full border border-black text-lg px-2"
+              placeholder="Yahoo! Conf"
+            ></Field>
+          </div>
+
+          <div className="flex flex-col space-y-1">
+            <label
+              className="font-semibold text-sm text-gray-900"
+              htmlFor="url"
+            >
+              Event location
+            </label>
+
+            <Field
+              name="location"
+              type="text"
+              className="h-12 w-full border border-black text-lg px-2"
+              placeholder="Houston, TX"
+            ></Field>
+          </div>
+
+          <button
+            type="submit"
+            disabled={formikProps.isSubmitting}
+            className="w-full h-14 bg-black text-white font-bold text-xl"
+          >
+            Save
+          </button>
+        </Form>
+      )}
+    </Formik>
+  )
+}
+export default PresoDetails

--- a/components/PresoDetails.tsx
+++ b/components/PresoDetails.tsx
@@ -5,6 +5,7 @@ import type { Writeable } from '@common/utils'
 
 interface Props {
   readonly onSubmit: (values: PresoDetails) => Promise<void>
+  readonly onViewSurvey: (shortCode: string) => void
   readonly preso: Preso
 }
 
@@ -28,17 +29,18 @@ const onValidate = (values: PresoDetails) => {
 
 const PresoDetails: React.FC<Props> = (props) => {
   const { preso } = props
+
   return (
     <Formik
       initialValues={
         {
-          url: preso.url,
-          eventName: preso.eventName,
-          title: preso.title,
-          eventLocation: preso.eventLocation,
-          publishedContentUrl: preso.publishedContentUrl,
-          createdAt: preso.createdAt,
-          updatedAt: preso.updatedAt
+          url: preso.url || '',
+          eventName: preso.eventName || '',
+          title: preso.title || '',
+          eventLocation: preso.eventLocation || '',
+          publishedContentUrl: preso.publishedContentUrl || '',
+          createdAt: preso.createdAt || '',
+          updatedAt: preso.updatedAt || ''
         } as PresoDetails
       }
       onSubmit={props.onSubmit}
@@ -141,6 +143,14 @@ const PresoDetails: React.FC<Props> = (props) => {
             className="w-full h-14 bg-black text-white font-bold text-xl"
           >
             Save
+          </button>
+
+          <button
+            type="button"
+            className="w-full h-14 bg-black text-white font-bold text-xl"
+            onClick={() => props.onViewSurvey(preso.id)}
+          >
+            View Surveys Responses
           </button>
         </Form>
       )}

--- a/components/PresoDetails.tsx
+++ b/components/PresoDetails.tsx
@@ -1,11 +1,11 @@
-import { Preso, PresoForm as PresoDetails } from '@types'
+import { Preso, PresoDetails } from '@types'
 import { Field, FieldProps, Form, Formik, FormikErrors } from 'formik'
 import React from 'react'
 import type { Writeable } from '@common/utils'
 
 interface Props {
   readonly onSubmit: (values: PresoDetails) => Promise<void>
-  readonly preso?: Preso
+  readonly preso: Preso
 }
 
 const onValidate = (values: PresoDetails) => {
@@ -27,14 +27,18 @@ const onValidate = (values: PresoDetails) => {
 }
 
 const PresoDetails: React.FC<Props> = (props) => {
+  const { preso } = props
   return (
     <Formik
       initialValues={
         {
-          url: props.preso?.url || '',
-          eventName: props.preso?.eventName || '',
-          title: props.preso?.title || '',
-          eventLocation: props.preso?.eventLocation || ''
+          url: preso.url,
+          eventName: preso.eventName,
+          title: preso.title,
+          eventLocation: preso.eventLocation,
+          publishedContentUrl: preso.publishedContentUrl,
+          createdAt: preso.createdAt,
+          updatedAt: preso.updatedAt
         } as PresoDetails
       }
       onSubmit={props.onSubmit}
@@ -72,7 +76,7 @@ const PresoDetails: React.FC<Props> = (props) => {
           <div className="flex flex-col space-y-1">
             <label
               className="font-semibold text-sm text-gray-900"
-              htmlFor="url"
+              htmlFor="title"
             >
               Title
             </label>
@@ -87,7 +91,7 @@ const PresoDetails: React.FC<Props> = (props) => {
           <div className="flex flex-col space-y-1">
             <label
               className="font-semibold text-sm text-gray-900"
-              htmlFor="url"
+              htmlFor="eventName"
             >
               Event Name
             </label>
@@ -102,16 +106,32 @@ const PresoDetails: React.FC<Props> = (props) => {
           <div className="flex flex-col space-y-1">
             <label
               className="font-semibold text-sm text-gray-900"
-              htmlFor="url"
+              htmlFor="eventLocation"
             >
               Event location
             </label>
 
             <Field
-              name="location"
+              name="eventLocation"
               type="text"
               className="h-12 w-full border border-black text-lg px-2"
               placeholder="Houston, TX"
+            ></Field>
+          </div>
+
+          <div className="flex flex-col space-y-1">
+            <label
+              className="font-semibold text-sm text-gray-900"
+              htmlFor="publishedContentUrl"
+            >
+              Published content location
+            </label>
+
+            <Field
+              name="publishedContentUrl"
+              type="text"
+              className="h-12 w-full border border-black text-lg px-2"
+              placeholder="https://youtube.com"
             ></Field>
           </div>
 

--- a/db.sql
+++ b/db.sql
@@ -16,6 +16,7 @@ CREATE TABLE "Preso" (
 	"url" TEXT,
 	"shortCode" TEXT,
 	"userId" UUID NOT NULL,
+    "publishedContentUrl" TEXT,
 	"createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	"updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	CONSTRAINT "Preso_pkey" PRIMARY KEY ("id"),

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -4,7 +4,7 @@ import { NextPage } from 'next'
 import Head from 'next/head'
 
 const AccountPage: NextPage = () => {
-  const { session, supabaseClient } = useSupabase()
+  const { session, client: supabaseClient } = useSupabase()
 
   if (!session) {
     return <div>No session</div>

--- a/pages/groupies.tsx
+++ b/pages/groupies.tsx
@@ -15,7 +15,7 @@ interface AttendeeView {
 
 const Groupies: NextPage = () => {
   const [attendees, setAttendees] = useState<AttendeeView[]>([])
-  const { session, supabaseClient } = useSupabase()
+  const { session, client: supabaseClient } = useSupabase()
 
   useEffect(() => {
     const loadPresos = async () => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 
 const Home: NextPage = () => {
-  const { session, supabaseClient } = useSupabase()
+  const { session, client: supabaseClient } = useSupabase()
   const router = useRouter()
 
   useEffect(() => {

--- a/pages/preso/[id].tsx
+++ b/pages/preso/[id].tsx
@@ -1,0 +1,26 @@
+import { useSupabase } from '@common/supabaseProvider'
+import { GetServerSideProps, NextPage } from 'next'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+
+const PresoDetails: NextPage = () => {
+  const router = useRouter()
+  const { client: supabaseClient } = useSupabase()
+  const { id: presoId } = router.query
+
+  useEffect(() => {
+    // fetch preso details
+  }, [])
+
+  return <pre>{JSON.stringify(router.query, null, 2)}</pre>
+}
+
+// export const getServerSideProps: GetServerSideProps = (context) => {
+//   const { id: presoId } = context.query
+
+//   return {
+//     props: {}
+//   }
+// }
+
+export default PresoDetails

--- a/pages/preso/[id].tsx
+++ b/pages/preso/[id].tsx
@@ -1,18 +1,42 @@
 import { useSupabase } from '@common/supabaseProvider'
-import { GetServerSideProps, NextPage } from 'next'
+import { Preso } from '@types'
+import { NextPage } from 'next'
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 const PresoDetails: NextPage = () => {
   const router = useRouter()
-  const { client: supabaseClient } = useSupabase()
-  const { id: presoId } = router.query
+  const { client } = useSupabase()
+  const { id: shortCode } = router.query
+  const [preso, setPreso] = useState<Preso | null>(null)
 
   useEffect(() => {
-    // fetch preso details
-  }, [])
+    async function getPresoDetails() {
+      if (typeof shortCode !== 'string') {
+        return
+      }
 
-  return <pre>{JSON.stringify(router.query, null, 2)}</pre>
+      const { data, error } = await client
+        .from<Preso>('Preso')
+        .select()
+        .eq('shortCode', shortCode)
+        .single()
+
+      if (error) {
+        console.error(error)
+        return
+      }
+
+      if (data) {
+        console.log(data)
+        setPreso(data)
+      }
+    }
+
+    getPresoDetails()
+  }, [client, shortCode])
+
+  return <pre>{JSON.stringify(preso, null, 2)}</pre>
 }
 
 export default PresoDetails

--- a/pages/preso/[id].tsx
+++ b/pages/preso/[id].tsx
@@ -15,12 +15,4 @@ const PresoDetails: NextPage = () => {
   return <pre>{JSON.stringify(router.query, null, 2)}</pre>
 }
 
-// export const getServerSideProps: GetServerSideProps = (context) => {
-//   const { id: presoId } = context.query
-
-//   return {
-//     props: {}
-//   }
-// }
-
 export default PresoDetails

--- a/pages/preso/[id].tsx
+++ b/pages/preso/[id].tsx
@@ -1,4 +1,5 @@
 import { useSupabase } from '@common/supabaseProvider'
+import Details from '@components/PresoDetails'
 import { Preso } from '@types'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
@@ -36,7 +37,13 @@ const PresoDetails: NextPage = () => {
     getPresoDetails()
   }, [client, shortCode])
 
-  return <pre>{JSON.stringify(preso, null, 2)}</pre>
+  return preso ? (
+    <div>
+      <Details preso={preso} onSubmit={async () => Promise.resolve(console.log("Save button clicked")) }/>
+    </div>
+  ) : (
+    <div></div>
+  )
 }
 
 export default PresoDetails

--- a/pages/preso/[presoShortCode].tsx
+++ b/pages/preso/[presoShortCode].tsx
@@ -8,38 +8,44 @@ import { useEffect, useState } from 'react'
 const PresoDetails: NextPage = () => {
   const router = useRouter()
   const { client } = useSupabase()
-  const { id: shortCode } = router.query
+  const { presoShortCode } = router.query
   const [preso, setPreso] = useState<Preso | null>(null)
 
   useEffect(() => {
     async function getPresoDetails() {
-      if (typeof shortCode !== 'string') {
+      if (typeof presoShortCode !== 'string') {
         return
       }
 
       const { data, error } = await client
         .from<Preso>('Preso')
         .select()
-        .eq('shortCode', shortCode)
+        .eq('shortCode', presoShortCode)
         .single()
 
       if (error) {
         console.error(error)
-        return
       }
 
       if (data) {
-        console.log(data)
         setPreso(data)
       }
     }
 
     getPresoDetails()
-  }, [client, shortCode])
+  }, [client, presoShortCode])
 
   return preso ? (
     <div>
-      <Details preso={preso} onSubmit={async () => Promise.resolve(console.log("Save button clicked")) }/>
+      <Details
+        preso={preso}
+        onSubmit={async () =>
+          Promise.resolve(console.log('Save button clicked'))
+        }
+        onViewSurvey={(presoId) => {
+          router.push(`/response/${presoId}`)
+        }}
+      />
     </div>
   ) : (
     <div></div>

--- a/pages/presos.tsx
+++ b/pages/presos.tsx
@@ -9,7 +9,7 @@ import { useEffect, useState } from 'react'
 const Presos: NextPage = () => {
   const router = useRouter()
   const [presos, setPresos] = useState<Preso[]>([])
-  const { authState, session, supabaseClient } = useSupabase()
+  const { authState, session, client: supabaseClient } = useSupabase()
 
   useEffect(() => {
     const loadPresos = async () => {
@@ -47,7 +47,7 @@ const Presos: NextPage = () => {
             <ul>
               {presos.map((p) => (
                 <li key={p.id}>
-                  {p.eventName} {p.shortCode}
+                  <a href={`/preso/${p.shortCode}`}>{p.eventName}</a>
                 </li>
               ))}
             </ul>

--- a/pages/response/[presoId].tsx
+++ b/pages/response/[presoId].tsx
@@ -1,0 +1,57 @@
+import { useSupabase } from '@common/supabaseProvider'
+import { Survey } from '@types'
+import { NextPage } from 'next'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+
+interface AttendeeView {
+  presenter: string
+  preso: string
+  attendee: string
+  email: string
+  name: string
+  created_at: string
+}
+
+const SurveyResponses: NextPage = () => {
+  const router = useRouter()
+  const { client } = useSupabase()
+  const { presoId } = router.query
+  const [surveys, setSurveys] = useState<AttendeeView[]>([])
+
+  useEffect(() => {
+    async function getSurveyResponses() {
+      if (typeof presoId !== 'string') {
+        return
+      }
+
+      const { data, error } = await client
+        .from<AttendeeView>('attendees_view')
+        .select()
+        .eq('preso', presoId)
+
+      error && console.error(error)
+
+      console.log(data)
+
+      setSurveys(data || [])
+    }
+
+    getSurveyResponses()
+  }, [client, presoId])
+
+  return (
+    <div>
+      <h1>Survey Responses</h1>
+      <ul>
+        {surveys.map((s) => (
+          <li key={s.attendee}>
+            {s.name}-{s.email}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default SurveyResponses

--- a/types.ts
+++ b/types.ts
@@ -62,6 +62,8 @@ export type PresoForm = Omit<
   'id' | 'shortCode' | 'createdAt' | 'updatedAt'
 >
 
+export type PresoDetails = Omit<Preso, 'id' | 'userId' | 'shortCode'>
+
 export interface Survey {
   /** Just an ID for internal use. */
   readonly id: string

--- a/types.ts
+++ b/types.ts
@@ -47,6 +47,9 @@ export interface Preso {
   /** The location where the event took place. */
   readonly eventLocation?: string
 
+  /** The location where the published video or other content can be found. */
+  readonly publishedContentUrl?: string
+
   /** The time the presentation was created. */
   readonly createdAt?: string
 


### PR DESCRIPTION
Fixes #51.

## Solution

This PR adds a details page for presos.

## Testing

⚠️ If you don't have any presos created, you'll want to create at least 1 first. ⚠️ 

1. Start ngosi, `yarn start`
2. Navigate to the Presos page, http://localhost:3000/presos
3. Click on one of the presentations
4. Observe that you're taken to a page with a URL similar to `http://localhost:3000/preso/kb-lCfk`


## Resources

###### Preso detail page
<img width="1120" alt="Screen Shot 2022-01-12 at 5 32 23 PM" src="https://user-images.githubusercontent.com/1715082/149239678-3bc9beef-408e-4250-a00b-84829d1ebdb4.png">