### PR TITLE
Centering Preso Form on preso page

### DIFF
--- a/components/PresoForm.tsx
+++ b/components/PresoForm.tsx
@@ -35,7 +35,7 @@ const PresoForm: React.FC<Props> = (props) => {
       validate={onValidate}
     >
       {(formikProps) => (
-        <Form className="flex flex-col space-y-5">
+        <Form className="flex flex-col space-y-5 w-80">
           <div className="flex flex-col space-y-1">
             <label
               className="font-semibold text-sm text-gray-900"

--- a/pages/preso.tsx
+++ b/pages/preso.tsx
@@ -28,7 +28,7 @@ const Preso: NextPage = () => {
   }
 
   return (
-    <div className="flex flex-col min-h-screen min-w-full">
+    <div className="flex flex-col min-h-screen">
       <Head>
         <title>Ngosi</title>
         <link rel="icon" href="/favicon.ico" />
@@ -37,19 +37,19 @@ const Preso: NextPage = () => {
         <h1 className="text-3xl bg-black py-2 px-6 text-white">
           Add Presentation
         </h1>
-        <div className="pt-4 px-6">
-          <div className="mt-6">
+        <div className="pt-4 px-6 mt-6">
+          <div className="flex flex-col items-center justify-center">
             <PresentationForm onSubmit={(values) => onSubmit(values)} />
+            <button
+              className="w-80 h-14 bg-black text-white font-bold text-xl mt-5"
+              type="button"
+              onClick={() => {
+                router.replace('presos')
+              }}
+            >
+              Cancel
+            </button>
           </div>
-          <button
-            className="w-full h-14 bg-black text-white font-bold text-xl mt-5"
-            type="button"
-            onClick={() => {
-              router.replace('presos')
-            }}
-          >
-            Cancel
-          </button>
         </div>
       </main>
       <Footer />


### PR DESCRIPTION
Fixes : #8 

## Solution
I updated the CSS properties of `PresoForm` component and the `preso` page to center the whole preso form.
## Testing
1. Start the supabase CLI, `supabase start` 
2. `yarn dev`, to start the dev server
3.  Navigate to `localhost:3000/preso` (preso page) and observe the change made on the preso form


## Resources

###### Before adding styles
<img width="1437" alt="Screen Shot 2022-01-14 at 10 29 06 AM" src="https://user-images.githubusercontent.com/89279465/149542025-6630f520-a566-48fc-abfa-aab35b425724.png">


###### After adding styles
<img width="1436" alt="Screen Shot 2022-01-14 at 10 28 39 AM" src="https://user-images.githubusercontent.com/89279465/149542038-6d306e3f-b263-4cc8-8122-584d8c1e0477.png">


