### PR TITLE
Displaying the empty state when there are no presos

### DIFF
--- a/pages/presos.tsx
+++ b/pages/presos.tsx
@@ -38,7 +38,7 @@ const Presos: NextPage = () => {
       <div className="pt-4 px-6">
         <div className="mt-6">
           <ul>
-            {presos.length > 0 ? (
+            {presos.length ? (
               presos.map((p) => (
                 <li key={p.id}>
                   <a href={`/preso/${p.shortCode}`}>{p.eventName}</a>

--- a/pages/presos.tsx
+++ b/pages/presos.tsx
@@ -34,27 +34,31 @@ const Presos: NextPage = () => {
 
   return (
     <>
-        <h1 className="text-3xl bg-black py-2 px-6 text-white">Your Presos</h1>
-        <div className="pt-4 px-6">
-          <div className="mt-6">
-            <ul>
-              {presos.map((p) => (
+      <h1 className="text-3xl bg-black py-2 px-6 text-white">Your Presos</h1>
+      <div className="pt-4 px-6">
+        <div className="mt-6">
+          <ul>
+            {presos.length > 0 ? (
+              presos.map((p) => (
                 <li key={p.id}>
                   <a href={`/preso/${p.shortCode}`}>{p.eventName}</a>
                 </li>
-              ))}
-            </ul>
-          </div>
+              ))
+            ) : (
+              <p>You have no presentations at the time.</p>
+            )}
+          </ul>
         </div>
-        <button
-          className="w-full h-14 bg-black text-white font-bold text-xl mt-5"
-          type="button"
-          onClick={() => {
-            router.push('preso')
-          }}
-        >
-          Add New Preso
-        </button>
+      </div>
+      <button
+        className="w-full h-14 bg-black text-white font-bold text-xl mt-5"
+        type="button"
+        onClick={() => {
+          router.push('preso')
+        }}
+      >
+        Add New Preso
+      </button>
     </>
   )
 }


### PR DESCRIPTION
Fixes #36

## Solution

I added a simple conditional to the `presos` page to check if a preso exists.



## Testing
1. Start Supabase CLI, `supabase start`
2. Start the dev server, `yarn dev`
3. Navigate to the [presos page](http://localhost:3000/presos)
4. Observe that there is a text displayed when there are no presos


## Resources

###### Before adding conditional
<img width="1434" alt="Screen Shot 2022-01-31 at 10 50 12 PM" src="https://user-images.githubusercontent.com/89279465/151912183-b5d8daf7-bd66-47cc-9e19-f5247338b998.png">


###### After adding conditional
<img width="1439" alt="Screen Shot 2022-01-31 at 10 50 50 PM" src="https://user-images.githubusercontent.com/89279465/151912188-167f0728-aa01-4342-a9be-e9fe169e3532.png">

