### PR TITLE
Add logic to fetch and render surveys

### DIFF
--- a/components/FeedbackList.tsx
+++ b/components/FeedbackList.tsx
@@ -1,0 +1,51 @@
+import { SurveyFeedbackData } from 'pages/api/survey-feedback'
+import { useEffect, useState } from 'react'
+
+interface Props {
+  readonly presenterId: string
+}
+
+export const FeedbackList = (props: Props) => {
+  const [surveyResults, setSurveyResults] = useState<SurveyFeedbackData[]>([])
+
+  useEffect(() => {
+    const fetchFeedback = async (): Promise<void> => {
+      const apiResult = await fetch('/api/survey-feedback', {
+        method: 'POST',
+        body: JSON.stringify({ presenterId: props.presenterId })
+      })
+
+      if (apiResult.ok) {
+        const json = (await apiResult.json()) as SurveyFeedbackData[]
+        setSurveyResults((json as any).surveyFeedback)
+      }
+    }
+
+    fetchFeedback()
+  }, [props.presenterId])
+
+  console.log('Survey results', surveyResults)
+
+  return (
+    <>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Feedback</th>
+            <th>Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {surveyResults.map((x) => (
+            <tr key={x.attendeedId}>
+              <td>{x.attendeeName}</td>
+              <td>{x.feedback}</td>
+              <td>{x.createdAt}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  )
+}

--- a/pages/api/survey-feedback.ts
+++ b/pages/api/survey-feedback.ts
@@ -1,0 +1,61 @@
+import { AttendeesView } from '@types'
+import { StatusCodes } from 'http-status-codes'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { supabaseClient } from './common/supabase'
+
+interface SurveyFeedbackRequest {
+  readonly presenterId: string
+}
+
+export interface SurveyFeedbackData {
+  readonly attendeedId: string
+  readonly attendeeName: string
+  readonly feedback: string
+  readonly createdAt: string
+}
+
+type Data =
+  | {
+      surveyFeedback: Array<SurveyFeedbackData>
+    }
+  | {
+      error: string
+    }
+
+export default async function asynchandler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+) {
+  try {
+    const { presenterId } = JSON.parse(req.body) as SurveyFeedbackRequest
+
+    // Lookup survey responsed for given presenterId
+    const { data, error } = await supabaseClient
+      .from<AttendeesView>('attendees_view')
+      .select()
+      .not('feedback', 'eq', null)
+      .eq('presenter', presenterId)
+
+    if (error)
+      return res.status(StatusCodes.NOT_FOUND).json({ error: error.message })
+
+    console.log(data)
+    data &&
+      res.status(StatusCodes.OK).json({
+        surveyFeedback: data.map((x) => {
+          return {
+            attendeedId: x.attendee,
+            attendeeName: x.name,
+            createdAt: x.created_at,
+            feedback: x.feedback
+          } as SurveyFeedbackData
+        })
+      })
+  } catch (error) {
+    console.error(error)
+
+    return res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ error: (error as Error).message })
+  }
+}

--- a/pages/api/survey.ts
+++ b/pages/api/survey.ts
@@ -13,8 +13,7 @@ type Data =
     }
 
 /**
- * 1. Fetch the preso using the short code
- * 2. Pluck userId property from record
+ *
  */
 export default async function asynchandler(
   req: NextApiRequest,
@@ -23,12 +22,14 @@ export default async function asynchandler(
   try {
     const { presoShortCode } = JSON.parse(req.body)
 
+    // Lookup preso by shortCode
     const presoResult = await supabaseClient
       .from<Preso>('Preso')
       .select()
       .eq('shortCode', presoShortCode)
       .maybeSingle()
 
+    // Find the presenter of the preso
     const presenterResult = await supabaseClient
       .from<Profile>('profiles')
       .select()

--- a/pages/groupies.tsx
+++ b/pages/groupies.tsx
@@ -37,9 +37,7 @@ const Groupies: NextPage = () => {
 
   return (
     <>
-      <h1 className="text-3xl bg-black py-2 px-6 text-white">
-        Your Groupies
-      </h1>
+      <h1 className="text-3xl bg-black py-2 px-6 text-white">Your Audience</h1>
       <div className="pt-4 px-6">
         <div className="mt-6">
           <ul>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,4 @@
 import { useSupabase } from '@common/supabaseProvider'
-import Auth from '@components/Auth'
 import { NextPage } from 'next'
 import Head from 'next/head'
 import { useRouter } from 'next/router'

--- a/pages/surveys.tsx
+++ b/pages/surveys.tsx
@@ -1,0 +1,29 @@
+import { useSupabase } from '@common/supabaseProvider'
+import { FeedbackList } from '@components/FeedbackList'
+import { NextPage } from 'next'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+
+const SurveysPage: NextPage = () => {
+  const router = useRouter()
+  const { authState, session } = useSupabase()
+
+  useEffect(() => {
+    if (authState !== 'authenticated') {
+      router.replace('/signin')
+    }
+  }, [authState, router])
+
+  return (
+    <>
+      <h1>Survey Responses</h1>
+      <FeedbackList
+        presenterId={
+          session?.user?.id || 'ce32f57d-c350-4464-8837-c3aad7178064'
+        }
+      />
+    </>
+  )
+}
+
+export default SurveysPage

--- a/types.ts
+++ b/types.ts
@@ -95,6 +95,9 @@ export interface Survey {
    */
   readonly notifyOfOtherTalks: boolean
 
+  /** The feedback they'd like to share with the presenter */
+  readonly feedback?: string
+
   /** The time the survey was completed. */
   readonly createdAt?: string
 }
@@ -122,4 +125,14 @@ export interface Attendee {
   readonly id: string
   readonly fullName: string
   readonly email: string
+}
+
+export interface AttendeesView {
+  readonly presenter: string
+  readonly preso: string
+  readonly attendee: string
+  readonly email: string
+  readonly name: string
+  readonly feedback: string
+  readonly created_at: string
 }


### PR DESCRIPTION
Fixes #<issue number>.

## Solution

**New**
* `survey-feedback` API endpoint for getting survey feedback for all a presenter's presentations
* `surveys` page for displaying survey feedback
* `FeedbackList` component responsible for fetching feedback for a given presenter

## Testing

Todo

